### PR TITLE
feat: add onAgentToolRequest callback for agent_tool_request events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-03-10
+
+### Added
+
+- `onAgentToolRequest` callback on `ConversationCallbacks`, fired whenever the agent initiates a tool call. Receives `toolName` and `toolCallId` as named parameters, enabling apps to display a loading/thinking indicator during tool execution.
+- `AgentToolRequest` event model with fields `toolName`, `toolCallId`, `toolType`, and `parameters`.
+- Handling for the `agent_tool_request` protocol event (previously silently dropped). For `tool_type: "client"` the SDK now executes the registered `ClientTool` and returns the result automatically, matching the behaviour introduced in Android SDK v0.7.1.
+
 ## [0.3.1] - 2026-02-19
 
 ### Changed
@@ -59,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - iOS 13.0+
 - Android API 21+
 
+[0.4.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.4.0
 [0.3.1]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.3.1
 [0.3.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.3.0
 [0.2.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.2.0

--- a/lib/src/messaging/message_handler.dart
+++ b/lib/src/messaging/message_handler.dart
@@ -96,6 +96,11 @@ class MessageHandler {
           _handleMcpConnectionStatus(json);
           break;
 
+        case 'agent_tool_request':
+          callbacks.onDebug?.call(json);
+          _handleAgentToolRequest(json);
+          break;
+
         case 'agent_tool_response':
           callbacks.onDebug?.call(json);
           _handleAgentToolResponse(json);
@@ -249,6 +254,41 @@ class MessageHandler {
   void _handleMcpConnectionStatus(Map<String, dynamic> json) {
     final status = McpConnectionStatus.fromJson(json);
     callbacks.onMcpConnectionStatus?.call(status);
+  }
+
+  Future<void> _handleAgentToolRequest(Map<String, dynamic> json) async {
+    try {
+      final request = AgentToolRequest.fromJson(json);
+
+      callbacks.onAgentToolRequest?.call(
+        toolName: request.toolName,
+        toolCallId: request.toolCallId,
+      );
+
+      // Execute registered client tool if applicable
+      if (request.toolType == 'client') {
+        final tool = clientTools?[request.toolName];
+        if (tool != null) {
+          final result = await tool.execute(request.parameters);
+          if (result != null) {
+            await _sendClientToolResponse(request.toolCallId, result);
+          }
+        } else {
+          // No handler registered — synthesise a ClientToolCall so the
+          // existing unhandled callback can be reused
+          callbacks.onUnhandledClientToolCall?.call(
+            ClientToolCall(
+              toolCallId: request.toolCallId,
+              toolName: request.toolName,
+              parameters: request.parameters,
+              eventId: 0,
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      callbacks.onError?.call('Agent tool request handling failed', e);
+    }
   }
 
   void _handleAgentToolResponse(Map<String, dynamic> json) {

--- a/lib/src/models/callbacks.dart
+++ b/lib/src/models/callbacks.dart
@@ -53,6 +53,10 @@ class ConversationCallbacks {
   /// Called when MCP connection status changes
   final void Function(McpConnectionStatus status)? onMcpConnectionStatus;
 
+  /// Called when the agent initiates any tool call (webhook, client, system)
+  final void Function({required String toolName, required String toolCallId})?
+      onAgentToolRequest;
+
   /// Called when an agent tool response is received
   final void Function(AgentToolResponse response)? onAgentToolResponse;
 
@@ -94,6 +98,7 @@ class ConversationCallbacks {
     this.onUnhandledClientToolCall,
     this.onMcpToolCall,
     this.onMcpConnectionStatus,
+    this.onAgentToolRequest,
     this.onAgentToolResponse,
     this.onDebug,
     this.onEndCallRequested,

--- a/lib/src/models/events.dart
+++ b/lib/src/models/events.dart
@@ -220,6 +220,40 @@ class McpIntegration {
   }
 }
 
+/// Agent tool request event (fired when the agent initiates any tool call)
+class AgentToolRequest {
+  /// Name of the tool being invoked
+  final String toolName;
+
+  /// Tool call identifier
+  final String toolCallId;
+
+  /// Tool type (e.g., "client", "webhook", "system")
+  final String toolType;
+
+  /// Parameters passed to the tool
+  final Map<String, dynamic> parameters;
+
+  AgentToolRequest({
+    required this.toolName,
+    required this.toolCallId,
+    required this.toolType,
+    required this.parameters,
+  });
+
+  factory AgentToolRequest.fromJson(Map<String, dynamic> json) {
+    final agentToolRequest =
+        json['agent_tool_request'] as Map<String, dynamic>;
+    return AgentToolRequest(
+      toolName: agentToolRequest['tool_name'] as String,
+      toolCallId: agentToolRequest['tool_call_id'] as String,
+      toolType: agentToolRequest['tool_type'] as String,
+      parameters:
+          agentToolRequest['parameters'] as Map<String, dynamic>? ?? {},
+    );
+  }
+}
+
 /// Agent tool response
 class AgentToolResponse {
   /// Tool name

--- a/lib/src/models/events.dart
+++ b/lib/src/models/events.dart
@@ -242,14 +242,12 @@ class AgentToolRequest {
   });
 
   factory AgentToolRequest.fromJson(Map<String, dynamic> json) {
-    final agentToolRequest =
-        json['agent_tool_request'] as Map<String, dynamic>;
+    final agentToolRequest = json['agent_tool_request'] as Map<String, dynamic>;
     return AgentToolRequest(
       toolName: agentToolRequest['tool_name'] as String,
       toolCallId: agentToolRequest['tool_call_id'] as String,
       toolType: agentToolRequest['tool_type'] as String,
-      parameters:
-          agentToolRequest['parameters'] as Map<String, dynamic>? ?? {},
+      parameters: agentToolRequest['parameters'] as Map<String, dynamic>? ?? {},
     );
   }
 }

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,2 +1,2 @@
 /// Package version
-const packageVersion = '0.3.1';
+const packageVersion = '0.4.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: elevenlabs_agents
 description: "Flutter SDK for ElevenLabs Agent Platform. Build conversational AI applications with real-time audio communication."
-version: 0.3.1
+version: 0.4.0
 homepage: https://elevenlabs.io
 repository: https://github.com/elevenlabs/elevenlabs-flutter
 

--- a/test/elevenlabs_flutter_test.dart
+++ b/test/elevenlabs_flutter_test.dart
@@ -340,6 +340,81 @@ void main() {
     });
   });
 
+  group('AgentToolRequest', () {
+    test('parses from JSON correctly', () {
+      final json = {
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'fetch_weather',
+          'tool_call_id': 'call-abc-123',
+          'tool_type': 'webhook',
+        },
+      };
+
+      final request = AgentToolRequest.fromJson(json);
+      expect(request.toolName, 'fetch_weather');
+      expect(request.toolCallId, 'call-abc-123');
+      expect(request.toolType, 'webhook');
+      expect(request.parameters, isEmpty);
+    });
+
+    test('parses parameters from JSON', () {
+      final json = {
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'lookup',
+          'tool_call_id': 'call-xyz-456',
+          'tool_type': 'client',
+          'parameters': {'query': 'hello', 'limit': 10},
+        },
+      };
+
+      final request = AgentToolRequest.fromJson(json);
+      expect(request.parameters, {'query': 'hello', 'limit': 10});
+    });
+
+    test('defaults parameters to empty map when absent', () {
+      final json = {
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'no_params_tool',
+          'tool_call_id': 'call-111',
+          'tool_type': 'system',
+        },
+      };
+
+      final request = AgentToolRequest.fromJson(json);
+      expect(request.parameters, isEmpty);
+    });
+  });
+
+  group('ConversationCallbacks - onAgentToolRequest', () {
+    test('can be registered and accepts named parameters', () {
+      String? receivedToolName;
+      String? receivedToolCallId;
+
+      final callbacks = ConversationCallbacks(
+        onAgentToolRequest: ({required toolName, required toolCallId}) {
+          receivedToolName = toolName;
+          receivedToolCallId = toolCallId;
+        },
+      );
+
+      callbacks.onAgentToolRequest?.call(
+        toolName: 'test_tool',
+        toolCallId: 'call-999',
+      );
+
+      expect(receivedToolName, 'test_tool');
+      expect(receivedToolCallId, 'call-999');
+    });
+
+    test('is null when not provided', () {
+      const callbacks = ConversationCallbacks();
+      expect(callbacks.onAgentToolRequest, isNull);
+    });
+  });
+
   group('ClientToolResult', () {
     test('converts to JSON correctly', () {
       final successResult = ClientToolResult.success({'data': 'test'});

--- a/test/message_handler_test.dart
+++ b/test/message_handler_test.dart
@@ -1,0 +1,278 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:elevenlabs_agents/elevenlabs_agents.dart';
+import 'package:elevenlabs_agents/src/connection/livekit_manager.dart';
+import 'package:elevenlabs_agents/src/messaging/message_handler.dart';
+
+/// Minimal fake LiveKitManager that feeds test messages into the handler
+/// without requiring a real LiveKit Room.
+class _FakeLiveKitManager extends LiveKitManager {
+  final _controller = StreamController<Map<String, dynamic>>.broadcast();
+  final List<Map<String, dynamic>> sentMessages = [];
+
+  @override
+  Stream<Map<String, dynamic>> get dataStream => _controller.stream;
+
+  @override
+  Future<void> sendMessage(Map<String, dynamic> message) async {
+    sentMessages.add(message);
+  }
+
+  void inject(Map<String, dynamic> message) => _controller.add(message);
+
+  void close() => _controller.close();
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('MessageHandler - agent_tool_request (webhook)', () {
+    test('fires onAgentToolRequest for webhook tool type', () async {
+      String? receivedToolName;
+      String? receivedToolCallId;
+
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: ConversationCallbacks(
+          onAgentToolRequest: ({required toolName, required toolCallId}) {
+            receivedToolName = toolName;
+            receivedToolCallId = toolCallId;
+          },
+        ),
+        liveKit: fakeManager,
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'fetch_weather',
+          'tool_call_id': 'call-abc',
+          'tool_type': 'webhook',
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(receivedToolName, 'fetch_weather');
+      expect(receivedToolCallId, 'call-abc');
+
+      handler.dispose();
+      fakeManager.close();
+    });
+
+    test('does not send a client_tool_result for webhook tool type', () async {
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: const ConversationCallbacks(),
+        liveKit: fakeManager,
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'backend_lookup',
+          'tool_call_id': 'call-xyz',
+          'tool_type': 'webhook',
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(fakeManager.sentMessages, isEmpty);
+
+      handler.dispose();
+      fakeManager.close();
+    });
+  });
+
+  group('MessageHandler - agent_tool_request (client tool)', () {
+    test('executes registered client tool and sends result', () async {
+      final fakeManager = _FakeLiveKitManager();
+      final tool = _EchoTool();
+
+      final handler = MessageHandler(
+        callbacks: const ConversationCallbacks(),
+        liveKit: fakeManager,
+        clientTools: {'echo': tool},
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'echo',
+          'tool_call_id': 'call-echo-1',
+          'tool_type': 'client',
+          'parameters': {'message': 'hello'},
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(fakeManager.sentMessages, hasLength(1));
+      final sent = fakeManager.sentMessages.first;
+      expect(sent['type'], 'client_tool_result');
+      expect(sent['tool_call_id'], 'call-echo-1');
+      expect(sent['result']['success'], true);
+
+      handler.dispose();
+      fakeManager.close();
+    });
+
+    test('fires onAgentToolRequest callback even for client tool type',
+        () async {
+      String? receivedToolName;
+
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: ConversationCallbacks(
+          onAgentToolRequest: ({required toolName, required toolCallId}) {
+            receivedToolName = toolName;
+          },
+        ),
+        liveKit: fakeManager,
+        clientTools: {'echo': _EchoTool()},
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'echo',
+          'tool_call_id': 'call-echo-2',
+          'tool_type': 'client',
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(receivedToolName, 'echo');
+
+      handler.dispose();
+      fakeManager.close();
+    });
+
+    test('fires onUnhandledClientToolCall when no tool is registered',
+        () async {
+      ClientToolCall? unhandled;
+
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: ConversationCallbacks(
+          onUnhandledClientToolCall: (toolCall) {
+            unhandled = toolCall;
+          },
+        ),
+        liveKit: fakeManager,
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'missing_tool',
+          'tool_call_id': 'call-miss-1',
+          'tool_type': 'client',
+          'parameters': {'key': 'value'},
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(unhandled, isNotNull);
+      expect(unhandled!.toolName, 'missing_tool');
+      expect(unhandled!.toolCallId, 'call-miss-1');
+      expect(unhandled!.parameters, {'key': 'value'});
+
+      handler.dispose();
+      fakeManager.close();
+    });
+
+    test('does not send result when client tool returns null', () async {
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: const ConversationCallbacks(),
+        liveKit: fakeManager,
+        clientTools: {'fire_forget': _FireForgetTool()},
+      );
+
+      handler.startListening();
+
+      fakeManager.inject({
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'fire_forget',
+          'tool_call_id': 'call-ff-1',
+          'tool_type': 'client',
+        },
+      });
+
+      await Future.delayed(Duration.zero);
+
+      expect(fakeManager.sentMessages, isEmpty);
+
+      handler.dispose();
+      fakeManager.close();
+    });
+  });
+
+  group('MessageHandler - agent_tool_request (debug)', () {
+    test('calls onDebug with the raw JSON', () async {
+      dynamic debugData;
+
+      final fakeManager = _FakeLiveKitManager();
+      final handler = MessageHandler(
+        callbacks: ConversationCallbacks(
+          onDebug: (data) => debugData = data,
+        ),
+        liveKit: fakeManager,
+      );
+
+      handler.startListening();
+
+      final message = {
+        'type': 'agent_tool_request',
+        'agent_tool_request': {
+          'tool_name': 'some_tool',
+          'tool_call_id': 'call-dbg',
+          'tool_type': 'webhook',
+        },
+      };
+
+      fakeManager.inject(message);
+
+      await Future.delayed(Duration.zero);
+
+      expect(debugData, equals(message));
+
+      handler.dispose();
+      fakeManager.close();
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test tool implementations
+// ---------------------------------------------------------------------------
+
+class _EchoTool implements ClientTool {
+  @override
+  Future<ClientToolResult?> execute(Map<String, dynamic> parameters) async {
+    return ClientToolResult.success({'echo': parameters['message']});
+  }
+}
+
+class _FireForgetTool implements ClientTool {
+  @override
+  Future<ClientToolResult?> execute(Map<String, dynamic> parameters) async {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #20 — handles the `agent_tool_request` protocol event that was previously dropped silently, making it impossible to show a loading/thinking indicator during agent tool execution.

- Add `AgentToolRequest` model (`toolName`, `toolCallId`, `toolType`, `parameters`)
- Add `onAgentToolRequest({required String toolName, required String toolCallId})` to `ConversationCallbacks`
- Handle `agent_tool_request` in `MessageHandler`:
  - Fires `onAgentToolRequest` for **all** tool types (webhook, client, system)
  - For `tool_type: "client"`: executes the registered `ClientTool` and sends `client_tool_result`, matching Android SDK v0.7.1 behaviour
  - For unregistered client tools: fires `onUnhandledClientToolCall`
- Add `test/message_handler_test.dart` with 6 unit tests covering all branches
- Add `AgentToolRequest` model and `ConversationCallbacks.onAgentToolRequest` tests to `elevenlabs_flutter_test.dart`

## Usage

```dart
ConversationCallbacks(
  onAgentToolRequest: ({required String toolName, required String toolCallId}) {
    // Tool call started — show thinking indicator
    setState(() => _isThinking = true);
  },
  onAgentToolResponse: (response) {
    // Tool call completed — hide thinking indicator
    setState(() => _isThinking = false);
  },
)
```

## Test plan

- [x] `flutter test` — all 56 tests pass
- [x] `flutter analyze` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)