### PR TITLE
fix: send client_tool_result with result as string per API spec to fix 1008 policy violation

### DIFF
--- a/lib/src/messaging/message_handler.dart
+++ b/lib/src/messaging/message_handler.dart
@@ -242,7 +242,8 @@ class MessageHandler {
     await liveKit.sendMessage({
       'type': 'client_tool_result',
       'tool_call_id': toolCallId,
-      'result': result.toJson(),
+      'result': result.toRawJson(),
+      'is_error': !result.success,
     });
   }
 

--- a/lib/src/messaging/message_handler.dart
+++ b/lib/src/messaging/message_handler.dart
@@ -242,7 +242,7 @@ class MessageHandler {
     await liveKit.sendMessage({
       'type': 'client_tool_result',
       'tool_call_id': toolCallId,
-      'result': result.toRawJson(),
+      'result': result.toJsonString(),
       'is_error': !result.success,
     });
   }

--- a/lib/src/tools/client_tools.dart
+++ b/lib/src/tools/client_tools.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Interface for client-side tool implementations
 abstract class ClientTool {
   /// Executes the tool with the given parameters
@@ -27,6 +29,9 @@ class ClientToolResult {
   /// Creates a failure result
   factory ClientToolResult.failure(String error) =>
       ClientToolResult._(success: false, error: error);
+  
+  /// Serializa el resultado a string JSON
+  String toRawJson() => json.encode(toJson());
 
   /// Converts to JSON for sending to the agent
   Map<String, dynamic> toJson() {

--- a/lib/src/tools/client_tools.dart
+++ b/lib/src/tools/client_tools.dart
@@ -30,7 +30,7 @@ class ClientToolResult {
   factory ClientToolResult.failure(String error) =>
       ClientToolResult._(success: false, error: error);
   
-  /// Serializa el resultado a string JSON
+  /// Serialize the result to a JSON string.
   String toJsonString() => json.encode(toJson());
 
   /// Converts to JSON for sending to the agent

--- a/lib/src/tools/client_tools.dart
+++ b/lib/src/tools/client_tools.dart
@@ -31,7 +31,7 @@ class ClientToolResult {
       ClientToolResult._(success: false, error: error);
   
   /// Serializa el resultado a string JSON
-  String toRawJson() => json.encode(toJson());
+  String toJsonString() => json.encode(toJson());
 
   /// Converts to JSON for sending to the agent
   Map<String, dynamic> toJson() {


### PR DESCRIPTION
## Problem

When sending a client tool result (`ClientToolResult`) to the agent, the LiveKit/WebSocket connection was closing with **1008 (policy violation) Invalid message received**. The error occurred both when sending the payload as an object (`result: { success, data }`) and when sending only the message as a string; in all cases the server rejected the message.

## Cause

According to the [ElevenLabs API documentation](https://elevenlabs.io/docs/eleven-agents/api-reference/eleven-agents/websocket#send.Client-Tool-Result), the `client_tool_result` event requires the **`result`** field to be of type **string** (not an object). The schema also includes the **`is_error`** (boolean) field to indicate whether the tool execution failed.

Sending `result` as an object caused the backend to reject the message and close the connection with 1008.

## Solution

1. **`lib/src/tools/client_tools.dart`**
   - Added the **`toRawJson()`** method, which serializes the result to a JSON string via `json.encode(toJson())`, so that `result` can be sent in the format required by the API.

2. **`lib/src/messaging/message_handler.dart`**
   - In `_sendClientToolResponse`, **`result`** is now sent using **`result.toRawJson()`** (string) instead of `result.toJson()` (object).
   - The **`is_error`** field is included according to the result: `!result.success` (true when there is a failure, false on success).

With this, the sent payload matches the API contract and the 1008 error no longer occurs.

## Reference

- [Send Client Tool Result – ElevenLabs WebSocket API](https://elevenlabs.io/docs/eleven-agents/api-reference/eleven-agents/websocket#send.Client-Tool-Result)