### PR TITLE
feat: add optional environment parameter for agent sessions

### DIFF
--- a/lib/src/client/conversation_client.dart
+++ b/lib/src/client/conversation_client.dart
@@ -130,6 +130,7 @@ class ConversationClient extends ChangeNotifier {
     String? agentId,
     String? conversationToken,
     String? userId,
+    String? environment,
     ConversationOverrides? overrides,
     Map<String, dynamic>? customLlmExtraBody,
     Map<String, dynamic>? dynamicVariables,
@@ -159,7 +160,10 @@ class ConversationClient extends ChangeNotifier {
         token = conversationToken;
       } else if (agentId != null) {
         // Public agent - fetch token
-        final result = await _tokenService.fetchToken(agentId: agentId);
+        final result = await _tokenService.fetchToken(
+          agentId: agentId,
+          environment: environment,
+        );
         token = result.token;
       } else {
         throw ArgumentError(

--- a/lib/src/connection/token_service.dart
+++ b/lib/src/connection/token_service.dart
@@ -10,10 +10,18 @@ class TokenService {
       : apiEndpoint = apiEndpoint ?? 'https://api.elevenlabs.io';
 
   /// Fetches a LiveKit token for public agents
-  Future<({String token})> fetchToken({required String agentId}) async {
+  Future<({String token})> fetchToken({
+    required String agentId,
+    String? environment,
+  }) async {
+    final queryParams = {'agent_id': agentId};
+    if (environment != null) {
+      queryParams['environment'] = environment;
+    }
+
     final uri = Uri.parse(
-      '$apiEndpoint/v1/convai/conversation/token?agent_id=$agentId',
-    );
+      '$apiEndpoint/v1/convai/conversation/token',
+    ).replace(queryParameters: queryParams);
 
     try {
       final response = await http.get(uri);

--- a/test/helpers/testable_client.dart
+++ b/test/helpers/testable_client.dart
@@ -35,6 +35,7 @@ class TestableConversationClient extends ChangeNotifier {
     String? agentId,
     String? conversationToken,
     String? userId,
+    String? environment,
     ConversationOverrides? overrides,
     Map<String, dynamic>? customLlmExtraBody,
     Map<String, dynamic>? dynamicVariables,


### PR DESCRIPTION
## Summary
- Adds an optional `environment` parameter to `startSession()` and `TokenService.fetchToken()` 
- When provided, includes `environment` as a query parameter in the token fetch request (`/v1/convai/conversation/token`)
- Defaults to `"production"` server-side when not specified — no breaking changes

## Test plan
- [ ] Verify `startSession(agentId: '...', environment: 'staging')` sends `?agent_id=...&environment=staging` to the token endpoint
- [ ] Verify omitting `environment` preserves existing behavior (no query param sent, server defaults to production)
- [ ] Verify `conversationToken` flow is unaffected (environment is only used for token fetch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)