### PR TITLE
Patch drift from backend for client tools

### DIFF
--- a/lib/src/messaging/message_handler.dart
+++ b/lib/src/messaging/message_handler.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import '../models/callbacks.dart';
 import '../models/conversation_status.dart';
 import '../models/events.dart';
@@ -239,10 +240,18 @@ class MessageHandler {
     String toolCallId,
     ClientToolResult result,
   ) async {
+    final String resultData;
+    if (result.success) {
+      final d = result.data;
+      resultData = d is String ? d : jsonEncode(d);
+    } else {
+      resultData = result.error ?? 'Unknown error';
+    }
     await liveKit.sendMessage({
       'type': 'client_tool_result',
       'tool_call_id': toolCallId,
-      'result': result.toJson(),
+      'result': resultData,
+      'is_error': !result.success,
     });
   }
 

--- a/test/message_handler_test.dart
+++ b/test/message_handler_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:elevenlabs_agents/elevenlabs_agents.dart';
@@ -119,7 +120,12 @@ void main() {
       final sent = fakeManager.sentMessages.first;
       expect(sent['type'], 'client_tool_result');
       expect(sent['tool_call_id'], 'call-echo-1');
-      expect(sent['result']['success'], true);
+      expect(sent['is_error'], false);
+      expect(sent['result'], isA<String>());
+      expect(
+        jsonDecode(sent['result'] as String),
+        {'echo': 'hello'},
+      );
 
       handler.dispose();
       fakeManager.close();


### PR DESCRIPTION
The backend expects this format for client tools

```
{
    "type": "client_tool_result",
    "tool_call_id": "tool.......",
    "result": "string result displayed to user",
    "is_error": true/false
  }
```

But this has drifted from what the Flutter SDK sends