### PR TITLE
fix: use toJson() for override serialization to include all fields

### DIFF
--- a/lib/src/utils/overrides.dart
+++ b/lib/src/utils/overrides.dart
@@ -5,13 +5,10 @@ Map<String, dynamic> constructOverrides(ConversationConfig config) {
   final overrides = config.overrides;
 
   final conversationConfigOverride = <String, dynamic>{
-    'agent': {
-      'first_message': overrides?.agent?.firstMessage,
-      'language': overrides?.agent?.language,
-      'prompt': overrides?.agent?.prompt,
-    },
-    'conversation': {'text_only': overrides?.conversation?.textOnly},
-    'tts': {'voice_id': overrides?.tts?.voiceId},
+    if (overrides?.agent != null) 'agent': overrides!.agent!.toJson(),
+    if (overrides?.conversation != null)
+      'conversation': overrides!.conversation!.toJson(),
+    if (overrides?.tts != null) 'tts': overrides!.tts!.toJson(),
   };
 
   final overridesEvent = <String, dynamic>{


### PR DESCRIPTION
## Summary
- `constructOverrides()` was hand-building override maps with only a subset of fields, silently dropping `modelId`, `stability`, `similarityBoost`, `style`, `useSpeakerBoost` from TTS overrides, plus `llm`, `temperature`, `maxTokens` from agent overrides, and `maxDurationSeconds`, `turnTimeoutSeconds` from conversation overrides
- Delegates to the existing `toJson()` methods on `AgentOverrides`, `TtsOverrides`, and `ConversationSettingsOverrides` which correctly serialize all fields
- Also avoids sending empty override sections (with null values) when no overrides are provided

Fixes #24

## Test plan
- [x] All 56 existing tests pass
- [ ] Manual test: start a session with `TtsOverrides(voiceId: '...', modelId: 'eleven_v3')` and verify V3 audio tags like `[laughs]` are synthesized correctly
- [ ] Manual test: start a session with `AgentOverrides(temperature: 0.5, maxTokens: 500)` and verify they are respected

🤖 Generated with [Claude Code](https://claude.com/claude-code)