### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-21
+
+### Changed
+
+- Bumped `livekit_client` dependency to `^2.7.0` (fixes build failures on Android and iOS)
+- Requires Flutter `>=3.38.0` due to transitive `meta ^1.17.0` requirement
+
 ## [0.5.1] - 2026-04-13
 
 Re-release of 0.5.0 with the version correctly bumped in package source files.
@@ -87,6 +94,7 @@ Re-release of 0.5.0 with the version correctly bumped in package source files.
 - iOS 13.0+
 - Android API 21+
 
+[0.6.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.6.0
 [0.5.1]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.5.1
 [0.5.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.5.0
 [0.4.0]: https://github.com/elevenlabs/elevenlabs-flutter/releases/tag/v0.4.0

--- a/lib/version.dart
+++ b/lib/version.dart
@@ -1,2 +1,2 @@
 /// Package version
-const packageVersion = '0.5.1';
+const packageVersion = '0.6.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: elevenlabs_agents
 description: "Flutter SDK for ElevenLabs Agent Platform. Build conversational AI applications with real-time audio communication."
-version: 0.5.1
+version: 0.6.0
 homepage: https://elevenlabs.io
 repository: https://github.com/elevenlabs/elevenlabs-flutter
 


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0 in `pubspec.yaml` and `lib/version.dart`
- Update CHANGELOG.md with 0.6.0 release notes

### Changes in this release

- Bumped `livekit_client` dependency to `^2.7.0` (fixes build failures on Android and iOS)
- Requires Flutter `>=3.38.0` due to transitive `meta ^1.17.0` requirement

## Test plan

- [x] `dart format .` — no changes
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all 56 tests pass
- [x] Grep for old version `0.5.1` — only historical CHANGELOG entries remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)