### PR TITLE
feat: expose real-time agent audio level via onAgentAudioLevel callback

### DIFF
--- a/lib/src/client/conversation_client.dart
+++ b/lib/src/client/conversation_client.dart
@@ -35,6 +35,8 @@ class ConversationClient extends ChangeNotifier {
 
   StreamSubscription<livekit.ConnectionState>? _stateSubscription;
   StreamSubscription<bool>? _speakingSubscription;
+  StreamSubscription<double>? _audioLevelSubscription;
+  StreamSubscription<double>? _userAudioLevelSubscription;
   StreamSubscription<String>? _disconnectSubscription;
 
   /// Current connection status
@@ -188,6 +190,18 @@ class ConversationClient extends ChangeNotifier {
         _isSpeaking = isSpeaking;
         notifyListeners();
         _callbacks?.onModeChange?.call(mode: _mode);
+      });
+
+      // Listen to agent audio level (0-1) for real-time visualizations
+      _audioLevelSubscription =
+          _liveKitManager.agentAudioLevelStream.listen((level) {
+        _callbacks?.onAgentAudioLevel?.call(audioLevel: level);
+      });
+
+      // Listen to local user audio level (0-1) for user spectrum
+      _userAudioLevelSubscription =
+          _liveKitManager.userAudioLevelStream.listen((level) {
+        _callbacks?.onUserAudioLevel?.call(audioLevel: level);
       });
 
       // Start message handling
@@ -356,6 +370,10 @@ class ConversationClient extends ChangeNotifier {
 
     await _speakingSubscription?.cancel();
     _speakingSubscription = null;
+    await _audioLevelSubscription?.cancel();
+    _audioLevelSubscription = null;
+    await _userAudioLevelSubscription?.cancel();
+    _userAudioLevelSubscription = null;
 
     await _disconnectSubscription?.cancel();
     _disconnectSubscription = null;

--- a/lib/src/connection/livekit_manager.dart
+++ b/lib/src/connection/livekit_manager.dart
@@ -40,6 +40,25 @@ class LiveKitManager {
   /// Stream that emits when agent starts/stops speaking
   Stream<bool> get speakingStateStream => _speakingStateController.stream;
 
+  /// Stream controller for agent audio level (0-1, real-time from LiveKit)
+  final _agentAudioLevelController = StreamController<double>.broadcast();
+
+  /// Stream of agent audio level (0-1). Emits whenever ActiveSpeakers changes,
+  /// reflecting the real loudness of the remote agent participant.
+  Stream<double> get agentAudioLevelStream =>
+      _agentAudioLevelController.stream;
+
+  /// Stream controller for the local user audio level (0-1)
+  final _userAudioLevelController = StreamController<double>.broadcast();
+
+  /// Stream of the local user audio level (0-1), sampled every 50ms from
+  /// `room.localParticipant.audioLevel`. Useful for "you are speaking"
+  /// visualizations.
+  Stream<double> get userAudioLevelStream => _userAudioLevelController.stream;
+
+  /// Polling timer for local participant audio level
+  Timer? _userLevelPollTimer;
+
   /// Current room instance
   Room? get room => _room;
 
@@ -115,15 +134,40 @@ class LiveKitManager {
           }
         })
         ..on<ActiveSpeakersChangedEvent>((event) {
-          // Check if agent is in the active speakers list
-          final agentIsSpeaking = event.speakers.any(
-            (speaker) => speaker.identity.startsWith('agent-'),
-          );
+          // Find the agent in active speakers
+          Participant? agentSpeaker;
+          for (final s in event.speakers) {
+            if (s.identity.startsWith('agent-')) {
+              agentSpeaker = s;
+              break;
+            }
+          }
+          final agentIsSpeaking = agentSpeaker != null;
           _handleSpeakingStateChange(agentIsSpeaking);
+
+          // Emit real-time audio level (0 when agent isn't speaking)
+          final level = agentSpeaker?.audioLevel ?? 0.0;
+          if (!_agentAudioLevelController.isClosed) {
+            _agentAudioLevelController.add(level);
+          }
         });
 
       // Connect to LiveKit server
       await _room!.connect(serverUrl, token);
+
+      // Poll local participant audio level for user spectrum visualizations.
+      // LiveKit updates `audioLevel` on the participant via internal events,
+      // but does not expose a Stream<double>, so we sample at 50ms (20Hz).
+      _userLevelPollTimer?.cancel();
+      _userLevelPollTimer =
+          Timer.periodic(const Duration(milliseconds: 50), (_) {
+        final lp = _room?.localParticipant;
+        if (lp == null) return;
+        final level = lp.audioLevel;
+        if (!_userAudioLevelController.isClosed) {
+          _userAudioLevelController.add(level);
+        }
+      });
 
       // Enable speakerphone on Android
       try {
@@ -210,6 +254,8 @@ class LiveKitManager {
     // Cancel any pending debounce timer
     _speakingDebounceTimer?.cancel();
     _speakingDebounceTimer = null;
+    _userLevelPollTimer?.cancel();
+    _userLevelPollTimer = null;
     _lastSpeakingState = false;
 
     // Dispose of event listener first
@@ -251,6 +297,8 @@ class LiveKitManager {
     await _disconnectStreamController.close();
     await _roomReadyController.close();
     await _speakingStateController.close();
+    await _agentAudioLevelController.close();
+    await _userAudioLevelController.close();
     await disconnect();
   }
 }

--- a/lib/src/models/callbacks.dart
+++ b/lib/src/models/callbacks.dart
@@ -81,6 +81,16 @@ class ConversationCallbacks {
   /// Called when a tentative agent response is received (streaming text)
   final void Function({required String response})? onTentativeAgentResponse;
 
+  /// Called with the agent's real-time audio level (0-1) from LiveKit.
+  /// Emitted whenever active speakers change. 0 when agent is silent.
+  /// Use this to power visualizations like waveforms or pulsing orbs.
+  final void Function({required double audioLevel})? onAgentAudioLevel;
+
+  /// Called with the local user's audio level (0-1), sampled at 20Hz from
+  /// the LiveKit `localParticipant.audioLevel`. Useful for spectrum/waveform
+  /// visualizations of the user speaking.
+  final void Function({required double audioLevel})? onUserAudioLevel;
+
   const ConversationCallbacks({
     this.onConnect,
     this.onDisconnect,
@@ -106,5 +116,7 @@ class ConversationCallbacks {
     this.onUserTranscript,
     this.onAgentResponseCorrection,
     this.onTentativeAgentResponse,
+    this.onAgentAudioLevel,
+    this.onUserAudioLevel,
   });
 }


### PR DESCRIPTION
## What

Adds a new optional callback `onAgentAudioLevel({required double audioLevel})` that forwards the real-time 0-1 loudness of the remote agent participant.

## Why

The SDK currently exposes only a coarse `isSpeaking` boolean via `onModeChange`. Consumers building waveform / orb visualizations need the continuous level, which LiveKit already produces through `ActiveSpeakersChangedEvent`.

With only the boolean, visualizations either look static or have to be faked with synthetic pulses, which feels wrong (real user complaint, see https://github.com/bpkitaoka/orion-project).

## How

- `LiveKitManager`: new `agentAudioLevelStream` (broadcast `Stream<double>`). The existing `ActiveSpeakersChangedEvent` handler now also picks the `agent-*` participant and emits its `audioLevel`. Emits `0.0` when the agent is not in the active speakers list.
- `ConversationClient`: subscribes to that stream and forwards via the new callback. Subscription is canceled in `_cleanup`.
- `ConversationCallbacks`: new `onAgentAudioLevel` field, fully optional and additive. Position in constructor preserves backwards compatibility.

## Behavior change

None for consumers that do not set the callback. Existing `onModeChange` semantics unchanged.

## Testing

Manually verified in a Flutter web build of a private app: the value updates at the LiveKit server cadence (~200ms) and tracks the agent voice closely. Drops to 0 between utterances.

Cadence is bounded by LiveKit; can be tuned server-side via `RoomOptions` if needed in future.