### PR TITLE
fix: harden ElevenLabs LiveKit session teardown against uncaught stream errors

### DIFF
--- a/lib/src/client/conversation_client.dart
+++ b/lib/src/client/conversation_client.dart
@@ -193,8 +193,14 @@ class ConversationClient extends ChangeNotifier {
       // Start message handling
       _messageHandler.startListening();
 
-      // Start waiting for room ready event BEFORE connecting
-      final roomReadyFuture = _liveKitManager.roomReadyStream.first;
+      // Start waiting for room ready event BEFORE connecting.
+      // Attach an error handler so that if connect() fails or the session is
+      // torn down before the room becomes ready, the roomReady controller
+      // closing without emitting doesn't surface "Bad state: No element" as an
+      // unhandled async error. The real failure is reported via connect()'s
+      // throw and the disconnect handler.
+      final roomReadyFuture =
+          _liveKitManager.roomReadyStream.first.catchError((Object _) {});
 
       // Connect to LiveKit (will emit roomReady event when done)
       await _liveKitManager.connect(wsUrl, token);

--- a/lib/src/connection/livekit_manager.dart
+++ b/lib/src/connection/livekit_manager.dart
@@ -47,6 +47,25 @@ class LiveKitManager {
   bool get isMuted =>
       !(_room?.localParticipant?.isMicrophoneEnabled() ?? false);
 
+  /// Adds [value] to [controller] only if it is still open.
+  ///
+  /// LiveKit room events can be delivered via a queued microtask after the
+  /// manager has been disposed and the controllers closed. Adding to a closed
+  /// broadcast controller throws "Bad state: Cannot add new events after
+  /// calling close", so every emission is routed through this guard.
+  void _safeAdd<T>(StreamController<T> controller, T value) {
+    if (!controller.isClosed) {
+      controller.add(value);
+    }
+  }
+
+  /// Adds [error] to [controller] only if it is still open. See [_safeAdd].
+  void _safeAddError<T>(StreamController<T> controller, Object error) {
+    if (!controller.isClosed) {
+      controller.addError(error);
+    }
+  }
+
   /// Connects to a LiveKit server
   Future<void> connect(String serverUrl, String token) async {
     try {
@@ -67,30 +86,32 @@ class LiveKitManager {
 
       _eventsListener!
         ..on<RoomConnectedEvent>((event) {
-          _stateStreamController.add(ConnectionState.connected);
+          _safeAdd(_stateStreamController, ConnectionState.connected);
         })
         ..on<RoomDisconnectedEvent>((event) {
-          _stateStreamController.add(ConnectionState.disconnected);
-          _disconnectStreamController.add('error');
+          _safeAdd(_stateStreamController, ConnectionState.disconnected);
+          _safeAdd(_disconnectStreamController, 'error');
         })
         ..on<RoomReconnectingEvent>((event) {
-          _stateStreamController.add(ConnectionState.reconnecting);
+          _safeAdd(_stateStreamController, ConnectionState.reconnecting);
         })
         ..on<RoomReconnectedEvent>((event) {
-          _stateStreamController.add(ConnectionState.connected);
+          _safeAdd(_stateStreamController, ConnectionState.connected);
         })
         ..on<DataReceivedEvent>((event) {
           // Handle incoming data messages
           try {
             final data = utf8.decode(event.data);
             final message = jsonDecode(data) as Map<String, dynamic>;
-            _dataStreamController.add(message);
+            _safeAdd(_dataStreamController, message);
           } on FormatException catch (e) {
-            _dataStreamController.addError(
+            _safeAddError(
+              _dataStreamController,
               Exception('Failed to decode message data: ${e.message}'),
             );
           } catch (e) {
-            _dataStreamController.addError(
+            _safeAddError(
+              _dataStreamController,
               Exception('Error processing data message: $e'),
             );
           }
@@ -98,8 +119,8 @@ class LiveKitManager {
         ..on<ParticipantDisconnectedEvent>((event) {
           // If the agent disconnects, we should end the session
           if (event.participant.identity.startsWith('agent-')) {
-            _stateStreamController.add(ConnectionState.disconnected);
-            _disconnectStreamController.add('agent');
+            _safeAdd(_stateStreamController, ConnectionState.disconnected);
+            _safeAdd(_disconnectStreamController, 'agent');
           }
         })
         ..on<AudioPlaybackStatusChanged>((event) async {
@@ -108,7 +129,8 @@ class LiveKitManager {
             try {
               await _room!.startAudio();
             } catch (e) {
-              _dataStreamController.addError(
+              _safeAddError(
+                _dataStreamController,
                 Exception('Failed to start audio playback: $e'),
               );
             }
@@ -129,7 +151,8 @@ class LiveKitManager {
       try {
         await Hardware.instance.setSpeakerphoneOn(true);
       } catch (e) {
-        _dataStreamController.addError(
+        _safeAddError(
+          _dataStreamController,
           Exception('Could not enable speakerphone: $e'),
         );
       }
@@ -145,9 +168,12 @@ class LiveKitManager {
       );
 
       // Emit room ready event - connection is fully established and ready for messages
-      _roomReadyController.add(null);
+      _safeAdd(_roomReadyController, null);
     } catch (e) {
-      _dataStreamController.addError(Exception('LiveKit Connection Error: $e'));
+      _safeAddError(
+        _dataStreamController,
+        Exception('LiveKit Connection Error: $e'),
+      );
       rethrow;
     }
   }
@@ -165,7 +191,10 @@ class LiveKitManager {
 
       await currentRoom.localParticipant?.publishData(bytes, reliable: true);
     } catch (e) {
-      _dataStreamController.addError(Exception('Failed to send message: $e'));
+      _safeAddError(
+        _dataStreamController,
+        Exception('Failed to send message: $e'),
+      );
       rethrow;
     }
   }
@@ -191,7 +220,7 @@ class LiveKitManager {
 
       if (_lastSpeakingState != isSpeaking) {
         _lastSpeakingState = isSpeaking;
-        _speakingStateController.add(isSpeaking);
+        _safeAdd(_speakingStateController, isSpeaking);
       }
     } else {
       // Agent stopped speaking - debounce to avoid flickering during pauses
@@ -199,7 +228,7 @@ class LiveKitManager {
       _speakingDebounceTimer = Timer(const Duration(milliseconds: 800), () {
         if (_lastSpeakingState != isSpeaking) {
           _lastSpeakingState = isSpeaking;
-          _speakingStateController.add(isSpeaking);
+          _safeAdd(_speakingStateController, isSpeaking);
         }
       });
     }
@@ -223,13 +252,15 @@ class LiveKitManager {
         await currentRoom.disconnect().timeout(
           const Duration(seconds: 3),
           onTimeout: () {
-            _dataStreamController.addError(
+            _safeAddError(
+              _dataStreamController,
               Exception('Disconnect timeout - forcing cleanup'),
             );
           },
         );
       } catch (e) {
-        _dataStreamController.addError(
+        _safeAddError(
+          _dataStreamController,
           Exception('Error during disconnect: $e'),
         );
       }
@@ -237,7 +268,10 @@ class LiveKitManager {
       try {
         await currentRoom.dispose();
       } catch (e) {
-        _dataStreamController.addError(Exception('Error disposing room: $e'));
+        _safeAddError(
+          _dataStreamController,
+          Exception('Error disposing room: $e'),
+        );
       }
 
       _room = null;
@@ -246,11 +280,16 @@ class LiveKitManager {
 
   /// Disposes of all resources
   Future<void> dispose() async {
+    // Tear down the room/listener BEFORE closing the controllers. Disconnecting
+    // can emit a final RoomDisconnectedEvent and the disconnect path itself
+    // reports errors on _dataStreamController; doing it first (combined with the
+    // _safeAdd guards) prevents "Cannot add new events after calling close".
+    await disconnect();
+
     await _dataStreamController.close();
     await _stateStreamController.close();
     await _disconnectStreamController.close();
     await _roomReadyController.close();
     await _speakingStateController.close();
-    await disconnect();
   }
 }


### PR DESCRIPTION
## Summary

Hardens the ElevenLabs LiveKit session lifecycle so that tearing down a Monika/voice session no longer produces uncaught stream errors. Two related fatal crashes, both seen in production via Firebase Crashlytics, both triggered during session teardown.

## Fix 1 — `Bad state: Cannot add new events after calling close`

`LiveKitManager.dispose()` closes the `StreamController`s and then calls `disconnect()`. A `RoomDisconnectedEvent` (and `disconnect()`'s own `addError` calls) can be delivered via a queued microtask **after** the controllers are closed → crash in the `RoomDisconnectedEvent` handler.


**Fix:** added `_safeAdd` / `_safeAddError` helpers that check `isClosed` before emitting, routed every `add`/`addError` through them, and reordered `dispose()` to `disconnect()` **before** closing the controllers.

## Fix 2 — `Bad state: No element`

`startSession` subscribes to `roomReadyStream.first` before calling `connect()`. If `connect()` throws — or the session is torn down before the room is ready — that future is never awaited, and when `dispose()` later closes `_roomReadyController` without emitting, `.first` completes with `Bad state: No element` as an **unhandled async error** → fatal.


**Fix:** attach `.catchError((Object _) {})` to that future. `_roomReadyController` is only ever `add(null)`'d (never `addError`), so the only error path is the benign "closed before ready" teardown case; the happy path is unchanged.

## Testing

No public API changes. `dart format`, `flutter analyze`, and the full `flutter test` suite (56 tests) all pass locally. `LiveKitManager`/`ConversationClient` require a live server and aren't unit-testable in the current harness (the suite mocks `LiveKitManager`), so no new tests are added.

Fixes #35 