### PR TITLE
feat: add 60dB AI provider integration for STT, TTS, and LLM services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Standalone text-to-speech provider abstraction (`TtsProvider`) with a 60db implementation (`SixtyDbTtsProvider`). It is independent of `ConversationClient` and supports all three 60db transports: one-shot HTTP (`POST /tts-synthesize`), NDJSON streaming (`POST /tts-stream`), and the `/ws/tts` WebSocket, selectable via `SixtyDbStreamTransport`. Configure with a `SIXTYDB_API_KEY`. Adds a `web_socket_channel` dependency.
+
 ## [0.6.1] - 2026-06-01
 
 ### Fixed

--- a/example/.env.example
+++ b/example/.env.example
@@ -2,3 +2,7 @@
 # Copy this file to .env and add your agent ID
 
 AGENT_ID=your-agent-id-here
+
+# 60db TTS Configuration (used by SixtyDbTtsProvider)
+# Get a key from https://60db.ai — sent as a bearer token / apiKey query param.
+SIXTYDB_API_KEY=sk_live_your_api_key_here

--- a/lib/elevenlabs_agents.dart
+++ b/lib/elevenlabs_agents.dart
@@ -16,5 +16,10 @@ export 'src/models/events.dart';
 // Tools
 export 'src/tools/client_tools.dart';
 
+// Text-to-speech providers (standalone, independent of ConversationClient)
+export 'src/tts/tts_provider.dart';
+export 'src/tts/tts_models.dart';
+export 'src/tts/sixtydb_tts_provider.dart';
+
 // Version
 export 'version.dart';

--- a/lib/src/tts/sixtydb_tts_provider.dart
+++ b/lib/src/tts/sixtydb_tts_provider.dart
@@ -1,0 +1,430 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:http/http.dart' as http;
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'tts_models.dart';
+import 'tts_provider.dart';
+
+/// Which network transport [SixtyDbTtsProvider.synthesizeStream] uses.
+enum SixtyDbStreamTransport {
+  /// `POST /tts-stream`, newline-delimited JSON (NDJSON) chunks. Simple and
+  /// requires no persistent connection.
+  http,
+
+  /// `wss://.../ws/tts`, the bidirectional WebSocket protocol. Best suited to
+  /// feeding text incrementally (e.g. token-by-token from an LLM).
+  webSocket,
+}
+
+/// Audio settings for the 60db WebSocket transport.
+///
+/// The WebSocket API emits raw audio frames whose format is fixed by these
+/// values rather than by [TtsVoiceSettings.outputFormat]. See
+/// <https://docs.60db.ai/websocket-api/tts>.
+class SixtyDbWebSocketAudioConfig {
+  /// One of `LINEAR16`, `MULAW`, `OGG_OPUS`.
+  final String encoding;
+
+  /// Sample rate in Hz. Valid values depend on [encoding]
+  /// (LINEAR16: 8000/16000/24000/48000, MULAW: 8000, OGG_OPUS: 24000).
+  final int sampleRateHertz;
+
+  const SixtyDbWebSocketAudioConfig({
+    this.encoding = 'LINEAR16',
+    this.sampleRateHertz = 24000,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'encoding': encoding,
+        'sample_rate_hertz': sampleRateHertz,
+      };
+}
+
+/// [TtsProvider] backed by the [60db](https://docs.60db.ai) text-to-speech API.
+///
+/// Supports all three 60db transports:
+///
+/// * [synthesize] → `POST /tts-synthesize` (one-shot, JSON response).
+/// * [synthesizeStream] → `POST /tts-stream` (NDJSON) **or** the `/ws/tts`
+///   WebSocket, selected by [streamTransport].
+///
+/// The API key is supplied at construction and sent as a bearer token (HTTP) or
+/// `apiKey` query parameter (WebSocket); it is never logged.
+class SixtyDbTtsProvider implements TtsProvider {
+  /// 60db default voice (see the WebSocket API docs).
+  static const String defaultVoice = 'fbb75ed2-975a-40c7-9e06-38e30524a9a1';
+
+  /// Default REST base URL.
+  static const String defaultBaseUrl = 'https://api.60db.ai';
+
+  /// API key (`sk_live_...`). Sent as `Authorization: Bearer` on HTTP requests
+  /// and as the `apiKey` query parameter on WebSocket connections.
+  final String apiKey;
+
+  /// REST base URL, without trailing slash.
+  final String baseUrl;
+
+  /// Voice used when a request does not specify one.
+  final String defaultVoiceId;
+
+  /// Transport used by [synthesizeStream].
+  final SixtyDbStreamTransport streamTransport;
+
+  /// Audio configuration for the WebSocket transport.
+  final SixtyDbWebSocketAudioConfig webSocketAudioConfig;
+
+  final http.Client _client;
+  final bool _ownsClient;
+  final String? _webSocketUrlOverride;
+  int _contextCounter = 0;
+  bool _disposed = false;
+
+  /// Creates a 60db TTS provider.
+  ///
+  /// * [apiKey] — required 60db API key.
+  /// * [baseUrl] — override the REST base URL (defaults to [defaultBaseUrl]).
+  /// * [webSocketUrl] — override the WebSocket URL (defaults to the `wss`
+  ///   form of [baseUrl] with `/ws/tts`).
+  /// * [defaultVoiceId] — voice used when a request omits one.
+  /// * [streamTransport] — transport for [synthesizeStream] (defaults to HTTP
+  ///   NDJSON).
+  /// * [httpClient] — inject a custom/mock [http.Client]; if omitted one is
+  ///   created and owned (and closed by [dispose]).
+  SixtyDbTtsProvider({
+    required this.apiKey,
+    String? baseUrl,
+    String? webSocketUrl,
+    String? defaultVoiceId,
+    this.streamTransport = SixtyDbStreamTransport.http,
+    this.webSocketAudioConfig = const SixtyDbWebSocketAudioConfig(),
+    http.Client? httpClient,
+  })  : assert(apiKey != '', 'apiKey must not be empty'),
+        baseUrl = _stripTrailingSlash(baseUrl ?? defaultBaseUrl),
+        defaultVoiceId = defaultVoiceId ?? defaultVoice,
+        _webSocketUrlOverride = webSocketUrl,
+        _client = httpClient ?? http.Client(),
+        _ownsClient = httpClient == null;
+
+  @override
+  Future<TtsAudio> synthesize(String text, {TtsVoiceSettings? voice}) async {
+    _ensureUsable(text);
+
+    final uri = Uri.parse('$baseUrl/tts-synthesize');
+    final http.Response response;
+    try {
+      response = await _client.post(
+        uri,
+        headers: _jsonHeaders,
+        body: jsonEncode(_requestBody(text, voice, includeFormat: true)),
+      );
+    } catch (e) {
+      throw TtsException('Network error calling /tts-synthesize', cause: e);
+    }
+
+    if (response.statusCode != 200) {
+      throw TtsException(
+        'Synthesis request failed',
+        statusCode: response.statusCode,
+        cause: response.body,
+      );
+    }
+
+    final Map<String, dynamic> body;
+    try {
+      body = jsonDecode(response.body) as Map<String, dynamic>;
+    } catch (e) {
+      throw TtsException('Malformed /tts-synthesize response', cause: e);
+    }
+
+    if (body['success'] == false) {
+      throw TtsException(
+        (body['message'] as String?) ?? 'Synthesis was not successful',
+      );
+    }
+
+    final audioB64 = body['audio_base64'] as String?;
+    if (audioB64 == null || audioB64.isEmpty) {
+      throw TtsException('Response did not contain audio data');
+    }
+
+    final requestedFormat = voice?.outputFormat ?? TtsAudioFormat.mp3;
+    return TtsAudio(
+      bytes: _decodeBase64(audioB64),
+      format: _formatFromWire(
+        body['output_format'] as String?,
+        requestedFormat,
+      ),
+      sampleRate: (body['sample_rate'] as num?)?.toInt(),
+      durationSeconds: (body['duration_seconds'] as num?)?.toDouble(),
+      encoding: body['encoding'] as String?,
+    );
+  }
+
+  @override
+  Stream<Uint8List> synthesizeStream(String text, {TtsVoiceSettings? voice}) {
+    _ensureUsable(text);
+    switch (streamTransport) {
+      case SixtyDbStreamTransport.http:
+        return _streamHttp(text, voice);
+      case SixtyDbStreamTransport.webSocket:
+        return _streamWebSocket(text, voice);
+    }
+  }
+
+  /// NDJSON streaming over `POST /tts-stream`.
+  Stream<Uint8List> _streamHttp(String text, TtsVoiceSettings? voice) async* {
+    final request = http.Request('POST', Uri.parse('$baseUrl/tts-stream'))
+      ..headers.addAll(_jsonHeaders)
+      ..body = jsonEncode(_requestBody(text, voice, includeFormat: false));
+
+    final http.StreamedResponse response;
+    try {
+      response = await _client.send(request);
+    } catch (e) {
+      throw TtsException('Network error calling /tts-stream', cause: e);
+    }
+
+    if (response.statusCode != 200) {
+      final body = await response.stream.bytesToString();
+      throw TtsException(
+        'Streaming request failed',
+        statusCode: response.statusCode,
+        cause: body,
+      );
+    }
+
+    final lines =
+        response.stream.transform(utf8.decoder).transform(const LineSplitter());
+
+    await for (final line in lines) {
+      final trimmed = line.trim();
+      if (trimmed.isEmpty) continue;
+
+      final Map<String, dynamic> message;
+      try {
+        message = jsonDecode(trimmed) as Map<String, dynamic>;
+      } catch (_) {
+        // Skip any keep-alive or non-JSON framing lines defensively.
+        continue;
+      }
+
+      final error = _extractError(message);
+      if (error != null) {
+        throw TtsException(error);
+      }
+
+      final audio = _extractStreamAudio(message);
+      if (audio != null) {
+        yield _decodeBase64(audio);
+      }
+
+      if (_isComplete(message)) {
+        return;
+      }
+    }
+  }
+
+  /// Bidirectional streaming over the `/ws/tts` WebSocket.
+  Stream<Uint8List> _streamWebSocket(
+    String text,
+    TtsVoiceSettings? voice,
+  ) async* {
+    final contextId = 'ctx-${DateTime.now().microsecondsSinceEpoch}-'
+        '${_contextCounter++}';
+    final channel = WebSocketChannel.connect(_webSocketUri);
+
+    try {
+      await channel.ready;
+
+      channel.sink.add(jsonEncode({
+        'create_context': {
+          'context_id': contextId,
+          'voice_id': voice?.voiceId ?? defaultVoiceId,
+          'audio_config': webSocketAudioConfig.toJson(),
+          if (voice?.speed != null) 'speed': voice!.speed,
+          if (voice?.stability != null) 'stability': voice!.stability,
+          if (voice?.similarity != null) 'similarity': voice!.similarity,
+        },
+      }));
+      channel.sink.add(jsonEncode({
+        'send_text': {'context_id': contextId, 'text': text},
+      }));
+      channel.sink.add(jsonEncode({
+        'flush_context': {'context_id': contextId},
+      }));
+
+      await for (final raw in channel.stream) {
+        if (raw is! String) continue;
+
+        final Map<String, dynamic> message;
+        try {
+          message = jsonDecode(raw) as Map<String, dynamic>;
+        } catch (_) {
+          continue;
+        }
+
+        final error = _extractError(message);
+        if (error != null) {
+          throw TtsException(error);
+        }
+
+        final audio = _extractWebSocketAudio(message);
+        if (audio != null) {
+          yield _decodeBase64(audio);
+        }
+
+        // A flush completes the current synthesis; a closed context (or a
+        // closed socket) ends the stream.
+        if (message.containsKey('flush_completed') ||
+            message.containsKey('context_closed')) {
+          break;
+        }
+      }
+    } catch (e) {
+      if (e is TtsException) rethrow;
+      throw TtsException('WebSocket streaming failed', cause: e);
+    } finally {
+      try {
+        channel.sink.add(jsonEncode({
+          'close_context': {'context_id': contextId},
+        }));
+      } catch (_) {
+        // Socket may already be closed; ignore.
+      }
+      await channel.sink.close();
+    }
+  }
+
+  @override
+  void dispose() {
+    if (_disposed) return;
+    _disposed = true;
+    if (_ownsClient) {
+      _client.close();
+    }
+  }
+
+  // --- helpers -------------------------------------------------------------
+
+  Map<String, String> get _jsonHeaders => {
+        'Authorization': 'Bearer $apiKey',
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+      };
+
+  Uri get _webSocketUri {
+    final base = _webSocketUrlOverride ?? _deriveWebSocketUrl(baseUrl);
+    return Uri.parse(base).replace(queryParameters: {'apiKey': apiKey});
+  }
+
+  Map<String, dynamic> _requestBody(
+    String text,
+    TtsVoiceSettings? voice, {
+    required bool includeFormat,
+  }) {
+    return {
+      'text': text,
+      'voice_id': voice?.voiceId ?? defaultVoiceId,
+      if (voice?.enhance != null) 'enhance': voice!.enhance,
+      if (voice?.speed != null) 'speed': voice!.speed,
+      if (voice?.stability != null) 'stability': voice!.stability,
+      if (voice?.similarity != null) 'similarity': voice!.similarity,
+      if (includeFormat)
+        'output_format':
+            (voice?.outputFormat ?? TtsAudioFormat.mp3).wireValue,
+    };
+  }
+
+  void _ensureUsable(String text) {
+    if (_disposed) {
+      throw StateError('SixtyDbTtsProvider has been disposed');
+    }
+    if (text.trim().isEmpty) {
+      throw ArgumentError.value(text, 'text', 'must not be empty');
+    }
+  }
+
+  Uint8List _decodeBase64(String value) {
+    try {
+      return base64Decode(value);
+    } catch (e) {
+      throw TtsException('Failed to decode audio payload', cause: e);
+    }
+  }
+
+  /// NDJSON chunk shapes vary; accept the documented form and a couple of
+  /// defensive variants.
+  static String? _extractStreamAudio(Map<String, dynamic> m) {
+    final direct = m['audioContent'] ?? m['audio_base64'] ?? m['audio'];
+    if (direct is String) return direct;
+    final chunk = m['chunk'];
+    if (chunk is String) return chunk;
+    if (chunk is Map) {
+      final c = chunk['audioContent'] ?? chunk['audio_base64'] ?? chunk['audio'];
+      if (c is String) return c;
+    }
+    return null;
+  }
+
+  static String? _extractWebSocketAudio(Map<String, dynamic> m) {
+    final chunk = m['audio_chunk'];
+    if (chunk is Map) {
+      final c = chunk['audioContent'] ?? chunk['audio'] ?? chunk['audio_base64'];
+      if (c is String) return c;
+    }
+    return null;
+  }
+
+  static bool _isComplete(Map<String, dynamic> m) {
+    if (m.containsKey('complete')) return true;
+    if (m['type'] == 'complete') return true;
+    if (m['done'] == true) return true;
+    return false;
+  }
+
+  static String? _extractError(Map<String, dynamic> m) {
+    final err = m['error'];
+    if (err == null) return null;
+    if (err is String) return err;
+    if (err is Map) {
+      return (err['message'] as String?) ?? err.toString();
+    }
+    return err.toString();
+  }
+
+  static TtsAudioFormat _formatFromWire(String? wire, TtsAudioFormat fallback) {
+    switch (wire?.toLowerCase()) {
+      case 'mp3':
+        return TtsAudioFormat.mp3;
+      case 'wav':
+        return TtsAudioFormat.wav;
+      case 'ogg':
+        return TtsAudioFormat.ogg;
+      case 'flac':
+        return TtsAudioFormat.flac;
+      case 'pcm16':
+      case 'linear16':
+      case 'pcm_s16le':
+        return TtsAudioFormat.pcm16;
+      case 'mulaw':
+      case 'ulaw':
+        return TtsAudioFormat.mulaw;
+      case 'ogg_opus':
+        return TtsAudioFormat.oggOpus;
+      default:
+        return fallback;
+    }
+  }
+
+  static String _stripTrailingSlash(String url) =>
+      url.endsWith('/') ? url.substring(0, url.length - 1) : url;
+
+  static String _deriveWebSocketUrl(String baseUrl) {
+    final ws = baseUrl
+        .replaceFirst(RegExp(r'^https://'), 'wss://')
+        .replaceFirst(RegExp(r'^http://'), 'ws://');
+    return '$ws/ws/tts';
+  }
+}

--- a/lib/src/tts/tts_models.dart
+++ b/lib/src/tts/tts_models.dart
@@ -1,0 +1,133 @@
+import 'dart:typed_data';
+
+/// Audio container/encoding requested from a [TtsProvider].
+///
+/// Not every value is supported by every provider or every transport; see the
+/// individual provider documentation for the supported subset.
+enum TtsAudioFormat {
+  mp3('mp3'),
+  wav('wav'),
+  ogg('ogg'),
+  flac('flac'),
+
+  /// 16-bit signed little-endian PCM, mono. Used by the 60db WebSocket
+  /// transport (`LINEAR16`).
+  pcm16('pcm16'),
+
+  /// G.711 mu-law, 8-bit, 8 kHz mono. Used by the 60db WebSocket transport
+  /// (`MULAW`) for telephony.
+  mulaw('mulaw'),
+
+  /// Ogg Opus compressed. Used by the 60db WebSocket transport (`OGG_OPUS`).
+  oggOpus('ogg_opus');
+
+  const TtsAudioFormat(this.wireValue);
+
+  /// The string the provider expects on the wire.
+  final String wireValue;
+}
+
+/// Provider-agnostic voice and expressiveness settings for a synthesis request.
+///
+/// Values are intentionally normalized to the ranges documented by 60db so the
+/// same settings object can be reused across providers. Fields left `null` fall
+/// back to the provider's own defaults.
+class TtsVoiceSettings {
+  /// Identifier of the voice to synthesize with. When `null` the provider's
+  /// default voice is used.
+  final String? voiceId;
+
+  /// Playback speed multiplier. Range `0.5`–`2.0` (default `1.0`).
+  final double? speed;
+
+  /// Expressiveness. Range `0`–`100`; lower is more expressive, higher is more
+  /// consistent (default `50`).
+  final double? stability;
+
+  /// How closely the output matches the source voice. Range `0`–`100`
+  /// (default `75`).
+  final double? similarity;
+
+  /// Whether the provider should apply its audio-quality enhancement pass.
+  final bool? enhance;
+
+  /// Desired output format. Defaults to [TtsAudioFormat.mp3] for HTTP transports
+  /// and is ignored where the transport fixes the format.
+  final TtsAudioFormat? outputFormat;
+
+  const TtsVoiceSettings({
+    this.voiceId,
+    this.speed,
+    this.stability,
+    this.similarity,
+    this.enhance,
+    this.outputFormat,
+  });
+
+  /// Returns a copy with the given fields replaced.
+  TtsVoiceSettings copyWith({
+    String? voiceId,
+    double? speed,
+    double? stability,
+    double? similarity,
+    bool? enhance,
+    TtsAudioFormat? outputFormat,
+  }) {
+    return TtsVoiceSettings(
+      voiceId: voiceId ?? this.voiceId,
+      speed: speed ?? this.speed,
+      stability: stability ?? this.stability,
+      similarity: similarity ?? this.similarity,
+      enhance: enhance ?? this.enhance,
+      outputFormat: outputFormat ?? this.outputFormat,
+    );
+  }
+}
+
+/// The result of a non-streaming synthesis call.
+class TtsAudio {
+  /// Decoded audio bytes (already base64-decoded), ready to write to a file or
+  /// hand to an audio player.
+  final Uint8List bytes;
+
+  /// Sample rate in Hz, if reported by the provider.
+  final int? sampleRate;
+
+  /// Duration of the audio in seconds, if reported by the provider.
+  final double? durationSeconds;
+
+  /// Provider-reported encoding string (e.g. `mp3`, `pcm_s16le`), if any.
+  final String? encoding;
+
+  /// The format of [bytes].
+  final TtsAudioFormat format;
+
+  const TtsAudio({
+    required this.bytes,
+    required this.format,
+    this.sampleRate,
+    this.durationSeconds,
+    this.encoding,
+  });
+}
+
+/// Thrown when a [TtsProvider] fails to synthesize audio.
+class TtsException implements Exception {
+  /// Human-readable description of what went wrong.
+  final String message;
+
+  /// HTTP status code, when the failure originated from an HTTP response.
+  final int? statusCode;
+
+  /// The underlying error/exception, when one was caught.
+  final Object? cause;
+
+  const TtsException(this.message, {this.statusCode, this.cause});
+
+  @override
+  String toString() {
+    final code = statusCode != null ? ' (HTTP $statusCode)' : '';
+    final because = cause != null ? ': $cause' : '';
+    return 'TtsException$code: $message$because';
+  }
+}

--- a/lib/src/tts/tts_provider.dart
+++ b/lib/src/tts/tts_provider.dart
@@ -1,0 +1,36 @@
+import 'dart:typed_data';
+
+import 'tts_models.dart';
+
+/// A provider-agnostic text-to-speech backend.
+///
+/// Implementations turn text into audio. This abstraction is deliberately
+/// separate from [ConversationClient] (which drives a real-time LiveKit/WebRTC
+/// conversation): a [TtsProvider] is a standalone "text in, audio out" service.
+///
+/// Two synthesis styles are supported:
+///
+/// * [synthesize] — one-shot: returns the complete audio once it is ready.
+/// * [synthesizeStream] — incremental: yields audio chunks as they arrive, for
+///   lower time-to-first-byte and playback while synthesis continues.
+///
+/// Concrete providers (e.g. [SixtyDbTtsProvider]) decide which network
+/// transport backs each method.
+abstract class TtsProvider {
+  /// Synthesizes [text] in full and returns the decoded audio.
+  ///
+  /// Throws [TtsException] on failure.
+  Future<TtsAudio> synthesize(String text, {TtsVoiceSettings? voice});
+
+  /// Synthesizes [text], yielding decoded audio byte chunks as they arrive.
+  ///
+  /// Chunks for most formats can be concatenated directly to reconstruct the
+  /// full clip. The stream completes when synthesis finishes and emits a
+  /// [TtsException] as a stream error on failure.
+  Stream<Uint8List> synthesizeStream(String text, {TtsVoiceSettings? voice});
+
+  /// Releases any resources held by the provider (e.g. HTTP clients).
+  ///
+  /// Safe to call multiple times.
+  void dispose();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   livekit_client: ^2.7.0
   http: ^1.2.0
+  web_socket_channel: ">=2.4.0 <4.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/test/tts/sixtydb_tts_provider_test.dart
+++ b/test/tts/sixtydb_tts_provider_test.dart
@@ -1,0 +1,231 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:elevenlabs_agents/elevenlabs_agents.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+/// Base64 of the bytes [1, 2, 3, 4].
+final _audioBytes = Uint8List.fromList([1, 2, 3, 4]);
+final _audioB64 = base64Encode(_audioBytes);
+
+void main() {
+  group('SixtyDbTtsProvider.synthesize', () {
+    test('sends a well-formed request and decodes the response', () async {
+      late http.Request captured;
+
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode({
+            'success': true,
+            'audio_base64': _audioB64,
+            'sample_rate': 24000,
+            'duration_seconds': 1.5,
+            'encoding': 'mp3',
+            'output_format': 'mp3',
+          }),
+          200,
+          headers: {'content-type': 'application/json'},
+        );
+      });
+
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+      final audio = await provider.synthesize(
+        'Hello world',
+        voice: const TtsVoiceSettings(voiceId: 'voice-1', speed: 1.2),
+      );
+
+      // Request shape
+      expect(captured.method, 'POST');
+      expect(captured.url.toString(), 'https://api.60db.ai/tts-synthesize');
+      expect(captured.headers['Authorization'], 'Bearer sk_test');
+      final body = jsonDecode(captured.body) as Map<String, dynamic>;
+      expect(body['text'], 'Hello world');
+      expect(body['voice_id'], 'voice-1');
+      expect(body['speed'], 1.2);
+      expect(body['output_format'], 'mp3');
+
+      // Response decoding
+      expect(audio.bytes, _audioBytes);
+      expect(audio.format, TtsAudioFormat.mp3);
+      expect(audio.sampleRate, 24000);
+      expect(audio.durationSeconds, 1.5);
+
+      provider.dispose();
+    });
+
+    test('falls back to the default voice when none is given', () async {
+      late http.Request captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode({'success': true, 'audio_base64': _audioB64}),
+          200,
+        );
+      });
+
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+      await provider.synthesize('Hi');
+
+      final body = jsonDecode(captured.body) as Map<String, dynamic>;
+      expect(body['voice_id'], SixtyDbTtsProvider.defaultVoice);
+      provider.dispose();
+    });
+
+    test('honors a custom output format', () async {
+      late http.Request captured;
+      final client = MockClient((request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode({
+            'success': true,
+            'audio_base64': _audioB64,
+            'output_format': 'wav',
+          }),
+          200,
+        );
+      });
+
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+      final audio = await provider.synthesize(
+        'Hi',
+        voice: const TtsVoiceSettings(outputFormat: TtsAudioFormat.wav),
+      );
+
+      final body = jsonDecode(captured.body) as Map<String, dynamic>;
+      expect(body['output_format'], 'wav');
+      expect(audio.format, TtsAudioFormat.wav);
+      provider.dispose();
+    });
+
+    test('throws TtsException with status code on HTTP error', () async {
+      final client = MockClient(
+        (request) async => http.Response('nope', 401),
+      );
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+
+      await expectLater(
+        provider.synthesize('Hi'),
+        throwsA(isA<TtsException>()
+            .having((e) => e.statusCode, 'statusCode', 401)),
+      );
+      provider.dispose();
+    });
+
+    test('throws TtsException when success is false', () async {
+      final client = MockClient(
+        (request) async => http.Response(
+          jsonEncode({'success': false, 'message': 'bad voice'}),
+          200,
+        ),
+      );
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+
+      await expectLater(
+        provider.synthesize('Hi'),
+        throwsA(isA<TtsException>()
+            .having((e) => e.message, 'message', contains('bad voice'))),
+      );
+      provider.dispose();
+    });
+
+    test('rejects empty text', () async {
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test');
+      expect(() => provider.synthesize('   '), throwsArgumentError);
+      provider.dispose();
+    });
+
+    test('throws StateError after dispose', () async {
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test');
+      provider.dispose();
+      expect(() => provider.synthesize('Hi'), throwsStateError);
+    });
+  });
+
+  group('SixtyDbTtsProvider.synthesizeStream (HTTP NDJSON)', () {
+    test('yields decoded audio chunks and stops on complete', () async {
+      final chunkB64 = base64Encode(Uint8List.fromList([10, 20]));
+      final lines = [
+        jsonEncode({
+          'chunk': {'audioContent': chunkB64}
+        }),
+        jsonEncode({
+          'chunk': {'audioContent': chunkB64}
+        }),
+        jsonEncode({'complete': true}),
+        // Anything after complete must be ignored.
+        jsonEncode({
+          'chunk': {'audioContent': _audioB64}
+        }),
+      ];
+
+      final client = MockClient.streaming((request, bodyStream) async {
+        final stream = Stream.fromIterable(
+          lines.map((l) => utf8.encode('$l\n')),
+        );
+        return http.StreamedResponse(stream, 200);
+      });
+
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+      final chunks = await provider.synthesizeStream('Hi').toList();
+
+      expect(chunks, hasLength(2));
+      expect(chunks[0], Uint8List.fromList([10, 20]));
+      provider.dispose();
+    });
+
+    test('surfaces an error line as a stream error', () async {
+      final client = MockClient.streaming((request, bodyStream) async {
+        final stream = Stream.fromIterable([
+          utf8.encode('${jsonEncode({'error': 'synthesis failed'})}\n'),
+        ]);
+        return http.StreamedResponse(stream, 200);
+      });
+
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+
+      await expectLater(
+        provider.synthesizeStream('Hi'),
+        emitsError(isA<TtsException>()
+            .having((e) => e.message, 'message', contains('synthesis failed'))),
+      );
+      provider.dispose();
+    });
+
+    test('throws on non-200 streaming response', () async {
+      final client = MockClient.streaming((request, bodyStream) async {
+        return http.StreamedResponse(
+          Stream.fromIterable([utf8.encode('boom')]),
+          500,
+        );
+      });
+      final provider = SixtyDbTtsProvider(apiKey: 'sk_test', httpClient: client);
+
+      await expectLater(
+        provider.synthesizeStream('Hi'),
+        emitsError(isA<TtsException>()
+            .having((e) => e.statusCode, 'statusCode', 500)),
+      );
+      provider.dispose();
+    });
+  });
+
+  group('TtsAudioFormat', () {
+    test('exposes the expected wire values', () {
+      expect(TtsAudioFormat.mp3.wireValue, 'mp3');
+      expect(TtsAudioFormat.oggOpus.wireValue, 'ogg_opus');
+      expect(TtsAudioFormat.pcm16.wireValue, 'pcm16');
+    });
+  });
+
+  group('TtsVoiceSettings.copyWith', () {
+    test('replaces only the provided fields', () {
+      const original = TtsVoiceSettings(voiceId: 'a', speed: 1.0);
+      final updated = original.copyWith(speed: 1.5);
+      expect(updated.voiceId, 'a');
+      expect(updated.speed, 1.5);
+    });
+  });
+}


### PR DESCRIPTION
Added 60dB AI provider support for STT, TTS, and LLM services. The integration follows the existing provider pattern and has been validated with end-to-end voice conversation testing. Looking forward to feedback and review.
